### PR TITLE
Add missing secretsmanager:ListSecrets permission to EC2 instance role

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -31,7 +31,9 @@ resource "aws_iam_policy" "github_runner" {
       {
         Effect = "Allow"
         Action = [
-          "secretsmanager:GetSecretValue"
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:ListSecrets",
+          "secretsmanager:DescribeSecret"
         ]
         Resource = aws_secretsmanager_secret.github_runner_credentials.arn
       },


### PR DESCRIPTION
This PR adds the missing `secretsmanager:ListSecrets` permission to the EC2 instance role to resolve access denied errors during testing and ensure proper functionality of the deregistration script.