### PR TITLE
Update README.md to reflect Lambda-only deregistration architecture

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -2,14 +2,16 @@ name: checkov-static-analysis-scan
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "*" ]
-  pull_request:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  push:
+    branches: [ '*' ]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - '**/README.md'
+
 permissions: read-all
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a comprehensive step-by-step guide with detailed explanations, please refer 
 
 - **High Availability**: Maintains consistent runner capacity using AWS Auto Scaling Groups with automatic instance replacement across multiple Availability Zones
 - **Secure Authentication**: Uses GitHub App authentication for secure API access
-- **Automated Lifecycle Management**: Automatic runner registration and deregistration using Lambda functions
+- **Automated Lifecycle Management**: Automatic runner registration via user data script and deregistration using Lambda functions
 - **Automated Deregistration**: Prevents orphaned runners in GitHub organization using lifecycle hooks and Lambda functions
 - **Unified Logging**: Centralized CloudWatch logging for complete runner lifecycle tracking
 - **Network Security**: Runs in private subnets with NAT Gateway for outbound internet access
@@ -47,7 +47,7 @@ The solution deploys:
 - **EFS file system** for shared runner workspace storage with optimized NFS parameters
 - **CloudWatch log groups** for unified lifecycle logging with structured format
 - **Secrets Manager** for secure GitHub App credentials storage
-- **SSM Parameter Store** for runner configuration scripts
+- **SSM Parameter Store** for NAT Gateway IP addresses
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a comprehensive step-by-step guide with detailed explanations, please refer 
 
 - **High Availability**: Maintains consistent runner capacity using AWS Auto Scaling Groups with automatic instance replacement across multiple Availability Zones
 - **Secure Authentication**: Uses GitHub App authentication for secure API access
-- **Automated Lifecycle Management**: Automatic runner registration and deregistration with dual mechanisms (Lambda + systemd service)
+- **Automated Lifecycle Management**: Automatic runner registration and deregistration using Lambda functions
 - **Automated Deregistration**: Prevents orphaned runners in GitHub organization using lifecycle hooks and Lambda functions
 - **Unified Logging**: Centralized CloudWatch logging for complete runner lifecycle tracking
 - **Network Security**: Runs in private subnets with NAT Gateway for outbound internet access
@@ -47,8 +47,7 @@ The solution deploys:
 - **EFS file system** for shared runner workspace storage with optimized NFS parameters
 - **CloudWatch log groups** for unified lifecycle logging with structured format
 - **Secrets Manager** for secure GitHub App credentials storage
-- **SSM Parameter Store** for runner configuration scripts and deregistration service
-- **Systemd Service** for backup deregistration mechanism
+- **SSM Parameter Store** for runner configuration scripts
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR updates the README.md documentation to accurately reflect the current Lambda-only deregistration architecture following the removal of the unreliable systemd service. Closes #54 